### PR TITLE
feat(records): add CLI with codegen and help commands

### DIFF
--- a/packages/records/bin/cube-records.js
+++ b/packages/records/bin/cube-records.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+function showHelp() {
+  // biome-ignore lint/suspicious/noConsole: CLI tool needs console output
+  console.log(
+    `
+@general-dexterity/cube-records v${packageJson.version}
+
+A type-safe wrapper for @cubejs-client/react with automatic TypeScript generation.
+
+Usage:
+  npx @general-dexterity/cube-records <command> [options]
+
+Commands:
+  help                          Show this help message
+  codegen [options]            Generate TypeScript definitions from your Cube.js schema
+
+Examples:
+  # Generate types to stdout
+  npx @general-dexterity/cube-records codegen
+
+  # Generate types to a file
+  npx @general-dexterity/cube-records codegen -o src/types/cube-records.d.ts
+
+  # Watch mode with custom endpoint
+  npx @general-dexterity/cube-records codegen -b https://api.example.com/cubejs-api -w -o src/types/cube-records.d.ts
+
+Using in your code:
+  import { useCubeRecordQuery } from '@general-dexterity/cube-records';
+  
+  // Type-safe queries with your generated types
+  const { data, isLoading, error } = useCubeRecordQuery({
+    cube: 'Orders',
+    measures: ['Orders.count'],
+    dimensions: ['Orders.status'],
+  });
+
+For more information, visit: https://github.com/general-dexterity/cube-records
+  `.trim()
+  );
+}
+
+if (
+  !command ||
+  command === 'help' ||
+  command === '--help' ||
+  command === '-h'
+) {
+  // Check if user wants help for a specific command
+  const helpTarget = args[1];
+  if (helpTarget === 'codegen') {
+    // Show codegen help
+    const codegenBin = join(
+      __dirname,
+      '..',
+      'node_modules',
+      '.bin',
+      'cube-records-codegen'
+    );
+    const child = spawn(codegenBin, ['--help'], {
+      stdio: 'inherit',
+      shell: true,
+    });
+    child.on('exit', (code) => {
+      process.exit(code || 0);
+    });
+  } else {
+    showHelp();
+    process.exit(0);
+  }
+} else if (command === 'codegen') {
+  const codegenBin = join(
+    __dirname,
+    '..',
+    'node_modules',
+    '.bin',
+    'cube-records-codegen'
+  );
+  const codegenArgs = args.slice(1);
+
+  const child = spawn(codegenBin, codegenArgs, {
+    stdio: 'inherit',
+    shell: true,
+  });
+
+  child.on('exit', (code) => {
+    process.exit(code || 0);
+  });
+} else {
+  // biome-ignore lint/suspicious/noConsole: CLI tool needs console output
+  console.error(`Unknown command: ${command}`);
+  // biome-ignore lint/suspicious/noConsole: CLI tool needs console output
+  console.error(
+    'Run "npx @general-dexterity/cube-records help" for usage information.'
+  );
+  process.exit(1);
+}

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -31,10 +31,7 @@
   ],
   "author": "Aliou Diallo <code@general-dexterity.com>",
   "license": "MIT",
-  "dependencies": {
-    "@cubejs-client/core": "^1.3.34",
-    "@cubejs-client/react": "^1.3.34"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@biomejs/biome": "latest",
     "@testing-library/react": "^16.3.0",

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -8,8 +8,12 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "cube-records": "./bin/cube-records.js"
+  },
   "files": [
     "dist",
+    "bin",
     "README.md"
   ],
   "scripts": {
@@ -22,7 +26,8 @@
     "format:check": "biome format .",
     "test": "vitest --run",
     "test:watch": "vitest --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "codegen": "cube-records-codegen"
   },
   "keywords": [
     "cubejs",
@@ -31,7 +36,9 @@
   ],
   "author": "Aliou Diallo <code@general-dexterity.com>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "@general-dexterity/cube-records-codegen": "workspace:*"
+  },
   "devDependencies": {
     "@biomejs/biome": "latest",
     "@testing-library/react": "^16.3.0",

--- a/packages/records/tests/cli.test.ts
+++ b/packages/records/tests/cli.test.ts
@@ -1,0 +1,96 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = join(__dirname, '..', 'bin', 'cube-records.js');
+const VERSION_REGEX = /\d+\.\d+\.\d+/;
+
+function runCLI(
+  args: string[]
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI_PATH, ...args]);
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code) => {
+      resolve({ stdout, stderr, code });
+    });
+  });
+}
+
+describe('CLI', () => {
+  describe('help command', () => {
+    it('shows help when no command is provided', async () => {
+      const { stdout, code } = await runCLI([]);
+      expect(code).toBe(0);
+      expect(stdout).toContain('@general-dexterity/cube-records');
+      expect(stdout).toContain('Usage:');
+      expect(stdout).toContain('Commands:');
+      expect(stdout).toContain('help');
+      expect(stdout).toContain('codegen');
+    });
+
+    it('shows help with help command', async () => {
+      const { stdout, code } = await runCLI(['help']);
+      expect(code).toBe(0);
+      expect(stdout).toContain('@general-dexterity/cube-records');
+      expect(stdout).toContain('Usage:');
+    });
+
+    it('shows help with --help flag', async () => {
+      const { stdout, code } = await runCLI(['--help']);
+      expect(code).toBe(0);
+      expect(stdout).toContain('@general-dexterity/cube-records');
+    });
+
+    it('shows help with -h flag', async () => {
+      const { stdout, code } = await runCLI(['-h']);
+      expect(code).toBe(0);
+      expect(stdout).toContain('@general-dexterity/cube-records');
+    });
+
+    it('shows codegen help with help codegen', async () => {
+      const { stdout, code } = await runCLI(['help', 'codegen']);
+      expect(code).toBe(0);
+      expect(stdout).toContain('Generate Cube Record type definitions');
+      expect(stdout).toContain('--baseUrl');
+      expect(stdout).toContain('--watch');
+      expect(stdout).toContain('--output');
+    });
+  });
+
+  describe('codegen command', () => {
+    it('shows codegen help with codegen --help', async () => {
+      const { stdout, code } = await runCLI(['codegen', '--help']);
+      expect(code).toBe(0);
+      expect(stdout).toContain('Generate Cube Record type definitions');
+      expect(stdout).toContain('--baseUrl');
+    });
+
+    it('shows version with codegen --version', async () => {
+      const { stdout, code } = await runCLI(['codegen', '--version']);
+      expect(code).toBe(0);
+      expect(stdout).toMatch(VERSION_REGEX);
+    });
+  });
+
+  describe('error handling', () => {
+    it('shows error for invalid command', async () => {
+      const { stderr, code } = await runCLI(['invalid-command']);
+      expect(code).toBe(1);
+      expect(stderr).toContain('Unknown command: invalid-command');
+      expect(stderr).toContain('npx @general-dexterity/cube-records help');
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@cubejs-client/react':
         specifier: ^1.3.34
         version: 1.3.34(react@19.1.0)
+      '@general-dexterity/cube-records-codegen':
+        specifier: workspace:*
+        version: link:../codegen
       react:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.1.0
@@ -2409,7 +2412,7 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.21))':
+  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
@@ -3645,7 +3648,7 @@ snapshots:
   vitest@3.1.3(@types/node@22.15.21)(jiti@2.4.2)(jsdom@26.1.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@22.15.21))
+      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3


### PR DESCRIPTION
## Summary
- Added CLI functionality to the records package with `help` and `codegen` subcommands
- Users can now use `npx @general-dexterity/cube-records help` and `npx @general-dexterity/cube-records codegen`
- Added comprehensive tests for the CLI

## Changes
- Add codegen as a dependency using workspace protocol  
- Create CLI binary with help and codegen subcommands
- Add codegen script to package.json for easy access
- Add comprehensive tests for CLI functionality

## Test plan
- [x] Run `pnpm test cli.test.ts` in the records package
- [x] Test `npx @general-dexterity/cube-records help`
- [x] Test `npx @general-dexterity/cube-records codegen --help`
- [x] Test `npx @general-dexterity/cube-records help codegen`

🤖 Generated with [Claude Code](https://claude.ai/code)